### PR TITLE
fix: Atualização campos obrigatórios

### DIFF
--- a/controledeestoque/.gitignore
+++ b/controledeestoque/.gitignore
@@ -26,5 +26,3 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
-
-src/main/resources/application.properties

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/controller/ActionController.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/controller/ActionController.java
@@ -47,6 +47,7 @@ public class ActionController {
     @PostMapping("/")
     public ResponseEntity<Action> postAction(@RequestBody ActionRequest data) {
         Action action = new Action();
+        action.setRa_rna(data.getRa_rna());
         action.setEntidade(data.getEntidade());
 //            action.setData_emprestimo(new Date(data.getData_emprestimo()));
 //            action.setData_devolucao(new Date(data.getData_devolucao()));

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/controller/HtmlController.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/controller/HtmlController.java
@@ -246,6 +246,7 @@ public class HtmlController {
             }
             else {
                 Action devolver = new Action();
+                devolver.setRa_rna(lastAction.getRa_rna());
                 devolver.setEntidade(lastAction.getEntidade());
                 devolver.setData_emprestimo(lastAction.getData_emprestimo());
                 devolver.setData_devolucao(lastAction.getData_devolucao());
@@ -319,8 +320,8 @@ public class HtmlController {
     public ModelAndView registrarEmprestimo(@ModelAttribute ActionRequest action, @RequestParam(name = "id") Integer id) {
         action.setId_item(id);
 
-
         Action postAction = new Action();
+        postAction.setRa_rna(action.getRa_rna());
         postAction.setEntidade(action.getEntidade());
         postAction.setData_emprestimo(action.getData_emprestimo());
         postAction.setData_devolucao(action.getData_devolucao());
@@ -357,6 +358,7 @@ public class HtmlController {
         item.setId_item(data.getId_item());
         item.setDescricao(data.getDescricao());
         item.setPotencia(data.getPotencia());
+        item.setPatrimonio(data.getPatrimonio());
         item.setData_nota_fiscal(data.getData_nota_fiscal());
         item.setLocalizacao_atual(data.getLocalizacao_atual());
         item.setData_entrada(data.getData_entrada());

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/controller/ItemController.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/controller/ItemController.java
@@ -59,6 +59,8 @@ public class ItemController {
 
         item.setPotencia(data.getPotencia());
 
+        item.setPatrimonio(data.getPatrimonio());
+
         item.setData_nota_fiscal(data.getData_nota_fiscal());
 
         item.setLocalizacao_atual(data.getLocalizacao_atual());
@@ -110,6 +112,7 @@ public class ItemController {
         itemInterface.findById(id_item).map(item -> {
             item.setDescricao(newItem.getDescricao());
             item.setPotencia(newItem.getPotencia());
+            item.setPatrimonio(newItem.getPatrimonio());
             item.setData_nota_fiscal(newItem.getData_nota_fiscal());
             item.setLocalizacao_atual(newItem.getLocalizacao_atual());
             item.setData_entrada(newItem.getData_entrada());

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/model/Action.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/model/Action.java
@@ -21,6 +21,8 @@ public class Action {
 
     private String entidade;
 
+    private String ra_rna;
+
     @Temporal(TemporalType.DATE)
     private String data_emprestimo;
 

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/model/ActionRequest.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/model/ActionRequest.java
@@ -15,9 +15,9 @@ import java.util.Date;
 @ToString
 public class ActionRequest {
 
+    private String ra_rna;
 
     private String entidade;
-
 
     private String data_emprestimo;
 

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/model/Item.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/model/Item.java
@@ -28,6 +28,8 @@ public class Item {
 
     private Integer potencia;
 
+    private String patrimonio;
+
     private String numero_de_serie;
 
     private String numero_nota_fiscal;

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/model/RequestItem.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/model/RequestItem.java
@@ -21,6 +21,8 @@ public class RequestItem {
 
         private Integer potencia;
 
+        private String patrimonio;
+
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         private Date data_entrada;
 

--- a/controledeestoque/src/main/resources/application.properties
+++ b/controledeestoque/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/controle_de_estoque?useSSL=false&serverTimezone=UTC-3
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/controledeestoque/src/main/resources/static/stylesheets/style.css
+++ b/controledeestoque/src/main/resources/static/stylesheets/style.css
@@ -1916,3 +1916,7 @@ ul.pagination {
 .button-modal[type="submit"]:hover {
     background-color: #0a8f66; /* Hover color */
 }
+
+.required {
+  color: red;
+}

--- a/controledeestoque/src/main/resources/templates/Emprestimo.html
+++ b/controledeestoque/src/main/resources/templates/Emprestimo.html
@@ -79,7 +79,11 @@
     </div>
   </div>
   <form id="formEmprestimo" th:action="@{/page/Emprestimo(id=${action.item.id_item})}" method="post">
-    <div class="input-container-novo-cadastro" >
+    <div class="input-container-novo-cadastro">
+      <div class="input-group">
+        <label for="input23">RA/RNA<span class="required">*</span></label>
+        <input id="input23" type="text" th:field="${data.ra_rna}" th:value="${action.ra_rna}" placeholder="20241234" required>
+      </div>
       <div class="input-group">
         <label for="input1">Entidade<span class="required">*</span></label>
         <input id="input1" type="text" th:field="${data.entidade}" th:value="${action.entidade}" placeholder="Biopark" required>
@@ -119,74 +123,77 @@
         <input id="input7" type="text" th:value="${action.item.localizacao.nome}" disabled>
       </div>
       <div class="input-group">
-        <label for="input8">Local Atual<span class="required">*</span></label>
-        <select id="input8" th:field="*{data.id_localizacao_atual}" required>
+        <label for="input8">Patrimônio</label>
+        <input id="input8" type="text" th:value="${action.item.patrimonio}" disabled>
+      </div>
+      <div class="input-group">
+        <label for="input9">Local Atual<span class="required">*</span></label>
+        <select id="input9" th:field="*{data.id_localizacao_atual}" required>
           <option th:each="location : ${locations}" th:value="${location.id_localizacao}" th:text="${location.nome}"></option>
         </select>
       </div>
       <div class="input-group">
-        <label for="input9">Responsável Pela Empresa<span class="required">*</span></label>
-        <input id="input9" type="text" value="" placeholder="Luiz" required>
+        <label for="input10">Responsável Pela Empresa<span class="required">*</span></label>
+        <input id="input10" type="text" value="" placeholder="Luiz" required>
       </div>
+    </div>
+    <div class="input-container-novo-cadastro">
       <div class="input-group">
-        <label for="input10">Responsável Empréstimo<span class="required">*</span></label>
-        <select id="input10" th:field="*{data.id_usuario}" required>
+        <label for="input11">Responsável Empréstimo<span class="required">*</span></label>
+        <select id="input11" th:field="*{data.id_usuario}" required>
           <option th:each="user : ${users}" th:value="${user.id_usuario}" th:text="${user.nome}"></option>
         </select>
-
+      </div>
+      <div class="input-group">
+        <label for="input12">Data de Empréstimo<span class="required">*</span></label>
+        <input id="input12" type="date" th:field="${data.data_emprestimo}" th:value=${data.data_emprestimo} required>
+      </div>
+      <div class="input-group">
+        <label for="input13">Data de Devolução<span class="required">*</span></label>
+        <input id="input13" type="date" th:field="${data.data_devolucao}" th:value=${data.data_devolucao} required>
+      </div>
+      <div class="input-group">
+        <label for="input14">Nota Fiscal</label>
+        <input id="input14" type="text" th:value="${action.item.numero_nota_fiscal}" disabled>
       </div>
     </div>
     <div class="input-container-novo-cadastro">
       <div class="input-group">
-        <label for="input11">Data de Empréstimo<span class="required">*</span></label>
-        <input id="input11" type="date" th:field="${data.data_emprestimo}" th:value=${data.data_emprestimo} required>
+        <label for="input15">Data da Nota Fiscal</label>
+        <input id="input15" type="text" value="02/02/2024" disabled>
       </div>
       <div class="input-group">
-        <label for="input12">Data de Devolução<span class="required">*</span></label>
-        <input id="input12" type="date" th:field="${data.data_devolucao}" th:value=${data.data_devolucao} required>
+        <label for="input16">Potência</label>
+        <input id="input16" type="text" th:value="${action.item.potencia}" disabled>
       </div>
       <div class="input-group">
-        <label for="input13">Nota Fiscal</label>
-        <input id="input13" type="text" th:value="${action.item.numero_nota_fiscal}" disabled>
+        <label for="input17">Última Manutenção<span class="required">*</span></label>
+        <input id="input17" type="date" th:value="${action.item.ultima_qualificacao}" required>
       </div>
       <div class="input-group">
-        <label for="input14">Data da Nota Fiscal</label>
-        <input id="input14" type="text" value="02/02/2024" disabled>
-      </div>
-    </div>
-    <div class="input-container-novo-cadastro">
-      <div class="input-group">
-        <label for="input15">Potência</label>
-        <input id="input15" type="text" th:value="${action.item.potencia}" disabled>
-      </div>
-      <div class="input-group">
-        <label for="input16">Última Manutenção<span class="required">*</span></label>
-        <input id="input16" type="date" th:value="${action.item.ultima_qualificacao}" required>
-      </div>
-      <div class="input-group">
-        <label for="input17">Próxima Manutenção<span class="required">*</span></label>
-        <input id="input17" type="date" th:value="${action.item.proxima_qualificacao}" required>
-      </div>
-      <div class="input-group">
-        <label for="input18">Prazo de Manutenção<span class="required">*</span></label>
-        <input id="input18" th:field="${data.prazo_manutencao}" type="date" required>
+        <label for="input18">Próxima Manutenção<span class="required">*</span></label>
+        <input id="input18" type="date" th:value="${action.item.proxima_qualificacao}" required>
       </div>
     </div>
     <div class="input-container-novo-cadastro">
       <div class="input-group">
-        <label for="input19">Comentários Sobre a Manutenção</label>
-        <input id="input19" type="text" placeholder="Comentário de manutenção">
+        <label for="input19">Prazo de Manutenção<span class="required">*</span></label>
+        <input id="input19" th:field="${data.prazo_manutencao}" type="date" required>
       </div>
       <div class="input-group">
-        <label for="input20">Status<span class="required">*</span></label>
-        <select id="input20" th:field="*{action.item.status}" required>
+        <label for="input20">Comentários Sobre a Manutenção</label>
+        <input id="input20" type="text" placeholder="Comentário de manutenção">
+      </div>
+      <div class="input-group">
+        <label for="input21">Status<span class="required">*</span></label>
+        <select id="input21" th:field="*{action.item.status}" required>
           <option value="">Selecione o status</option>
           <option th:each="status : ${statuses}" th:value="${status.id_status}" th:text="${status.nome}"></option>
         </select>
       </div>
       <div class="input-group">
-        <label for="input21">Anexos</label>
-        <input id="input21" type="text" value="Anexar novo arquivo">
+        <label for="input22">Anexos</label>
+        <input id="input22" type="text" placeholder="Anexar novo arquivo">
       </div>
     </div>
   </form>

--- a/controledeestoque/src/main/resources/templates/Emprestimo.html
+++ b/controledeestoque/src/main/resources/templates/Emprestimo.html
@@ -81,7 +81,7 @@
   <form id="formEmprestimo" th:action="@{/page/Emprestimo(id=${action.item.id_item})}" method="post">
     <div class="input-container-novo-cadastro" >
       <div class="input-group">
-        <label for="input1">Entidade</label>
+        <label for="input1">Entidade<span class="required">*</span></label>
         <input id="input1" type="text" th:field="${data.entidade}" th:value="${action.entidade}" placeholder="Biopark" required>
       </div>
       <div class="input-group">
@@ -89,7 +89,7 @@
         <input id="input2" type="text" th:value="${action.item.descricao}" disabled>
       </div>
       <div class="input-group">
-        <label for="input-disponibilidade">Disponibilidade</label>
+        <label for="input-disponibilidade">Disponibilidade<span class="required">*</span></label>
         <select id="input-disponibilidade" th:field="*{data.id_estado}" required>
           <option th:each="state : ${states}" th:value="${state.id_estado}"  th:text="${state.nome}"></option>
         </select>
@@ -119,20 +119,18 @@
         <input id="input7" type="text" th:value="${action.item.localizacao.nome}" disabled>
       </div>
       <div class="input-group">
-        <label for="input8">Local Atual</label>
+        <label for="input8">Local Atual<span class="required">*</span></label>
         <select id="input8" th:field="*{data.id_localizacao_atual}" required>
-          <option value=0>Selecione o local atual</option>
           <option th:each="location : ${locations}" th:value="${location.id_localizacao}" th:text="${location.nome}"></option>
         </select>
       </div>
       <div class="input-group">
-        <label for="input9">Responsável</label>
-        <input id="input9" type="text" value="Nome do responsável pela Empresa" placeholder="Luiz" required>
+        <label for="input9">Responsável Pela Empresa<span class="required">*</span></label>
+        <input id="input9" type="text" value="" placeholder="Luiz" required>
       </div>
       <div class="input-group">
-        <label for="input10">Responsável Empréstimo</label>
+        <label for="input10">Responsável Empréstimo<span class="required">*</span></label>
         <select id="input10" th:field="*{data.id_usuario}" required>
-          <option value=0>Selecione o usuário responsável</option>
           <option th:each="user : ${users}" th:value="${user.id_usuario}" th:text="${user.nome}"></option>
         </select>
 
@@ -140,12 +138,12 @@
     </div>
     <div class="input-container-novo-cadastro">
       <div class="input-group">
-        <label for="input11">Data de Empréstimo</label>
-        <input id="input11" type="date" th:field="${data.data_emprestimo}" th:value=${data.data_emprestimo}>
+        <label for="input11">Data de Empréstimo<span class="required">*</span></label>
+        <input id="input11" type="date" th:field="${data.data_emprestimo}" th:value=${data.data_emprestimo} required>
       </div>
       <div class="input-group">
-        <label for="input12">Data de Devolução</label>
-        <input id="input12" type="date" th:field="${data.data_devolucao}" th:value=${data.data_devolucao}>
+        <label for="input12">Data de Devolução<span class="required">*</span></label>
+        <input id="input12" type="date" th:field="${data.data_devolucao}" th:value=${data.data_devolucao} required>
       </div>
       <div class="input-group">
         <label for="input13">Nota Fiscal</label>
@@ -162,16 +160,16 @@
         <input id="input15" type="text" th:value="${action.item.potencia}" disabled>
       </div>
       <div class="input-group">
-        <label for="input16">Última Manutenção</label>
-        <input id="input16" type="date" th:value="${action.item.ultima_qualificacao}">
+        <label for="input16">Última Manutenção<span class="required">*</span></label>
+        <input id="input16" type="date" th:value="${action.item.ultima_qualificacao}" required>
       </div>
       <div class="input-group">
-        <label for="input17">Próxima Manutenção</label>
-        <input id="input17" type="date" th:value="${action.item.proxima_qualificacao}">
+        <label for="input17">Próxima Manutenção<span class="required">*</span></label>
+        <input id="input17" type="date" th:value="${action.item.proxima_qualificacao}" required>
       </div>
       <div class="input-group">
-        <label for="input18">Prazo de Manutenção</label>
-        <input id="input18" th:field="${data.prazo_manutencao}" type="date">
+        <label for="input18">Prazo de Manutenção<span class="required">*</span></label>
+        <input id="input18" th:field="${data.prazo_manutencao}" type="date" required>
       </div>
     </div>
     <div class="input-container-novo-cadastro">
@@ -180,7 +178,7 @@
         <input id="input19" type="text" placeholder="Comentário de manutenção">
       </div>
       <div class="input-group">
-        <label for="input20">Status</label>
+        <label for="input20">Status<span class="required">*</span></label>
         <select id="input20" th:field="*{action.item.status}" required>
           <option value="">Selecione o status</option>
           <option th:each="status : ${statuses}" th:value="${status.id_status}" th:text="${status.nome}"></option>

--- a/controledeestoque/src/main/resources/templates/NovoCadastro.html
+++ b/controledeestoque/src/main/resources/templates/NovoCadastro.html
@@ -84,15 +84,15 @@
 
       <div class="input-container-novo-cadastro">
         <div class="input-group">
-          <label for="input2">Item</label>
+          <label for="input2">Item<span class="required">*</span></label>
           <input id="input2" type="text" th:field="*{descricao}" placeholder="Notebook" required>
         </div>
         <div class="input-group">
-          <label for="input5">Número de Série</label>
+          <label for="input5">Número de Série<span class="required">*</span></label>
           <input id="input5" type="text" th:field="*{numero_de_serie}" placeholder="20222720" required>
         </div>
         <div class="input-group">
-          <label for="input-disponibilidade">Disponibilidade</label>
+          <label for="input-disponibilidade">Disponibilidade<span class="required">*</span></label>
           <select id="input-disponibilidade" th:field="*{estado}" required>
             <option value="">Selecione a disponibilidade</option>
             <option th:each="state : ${states}" th:value="${state.id_estado}" th:text="${state.nome}"></option>
@@ -101,21 +101,21 @@
       </div>
       <div class="input-container-novo-cadastro">
         <div class="input-group">
-          <label for="input3">Marca</label>
+          <label for="input3">Marca<span class="required">*</span></label>
           <select id="input3" th:field="*{marca}" required>
             <option value="">Selecione a marca</option>
             <option th:each="brand : ${brands}" th:value="${brand.id_marca}" th:text="${brand.nome}"></option>
           </select>
         </div>
         <div class="input-group">
-          <label for="input4">Modelo</label>
+          <label for="input4">Modelo<span class="required">*</span></label>
           <select id="input4" th:field="*{modelo}" required>
             <option value="">Selecione o modelo</option>
             <option th:each="model : ${models}" th:value="${model.id_model}" th:text="${model.nome}"></option>
           </select>
         </div>
         <div class="input-group">
-          <label for="input6">Categoria</label>
+          <label for="input6">Categoria<span class="required">*</span></label>
           <select id="input6" th:field="*{categoria}" required>
             <option value="">Selecione a categoria</option>
             <option th:each="category : ${categories}" th:value="${category.id_categoria}" th:text="${category.nome}"></option>
@@ -124,14 +124,14 @@
       </div>
       <div class="input-container-novo-cadastro">
         <div class="input-group">
-          <label for="input7">Origem</label>
+          <label for="input7">Origem<span class="required">*</span></label>
           <select id="input7" th:field="*{localizacao}" required>
             <option value="">Selecione o local de origem</option>
             <option th:each="location : ${locations}" th:value="${location.id_localizacao}" th:text="${location.nome}"></option>
           </select>
         </div>
         <div class="input-group">
-          <label for="input8">Local Atual</label>
+          <label for="input8">Local Atual<span class="required">*</span></label>
           <select id="input8" th:field="*{localizacao_atual}" required>
             <option value="">Selecione o local atual</option>
             <option th:each="location : ${locations}" th:value="${location.nome}" th:text="${location.nome}"></option>
@@ -139,44 +139,44 @@
         </div>
         <div class="input-group">
           <label for="input10">Potência</label>
-          <input id="input10" type="text" th:field="*{potencia}" placeholder="127" required>
+          <input id="input10" type="text" th:field="*{potencia}" placeholder="127">
         </div>
       </div>
       <div class="input-container-novo-cadastro">
         <div class="input-group">
-          <label for="input11">Nota Fiscal</label>
+          <label for="input11">Nota Fiscal<span class="required">*</span></label>
           <input id="input11" type="text" th:field="*{numero_nota_fiscal}" placeholder="123456789" required>
         </div>
         <div class="input-group">
-          <label for="input12">Data da Nota Fiscal</label>
+          <label for="input12">Data da Nota Fiscal<span class="required">*</span></label>
           <input id="input12" type="date" th:field="*{data_nota_fiscal}" placeholder="2024-03-30" required>
         </div>
         <div class="input-group">
-          <label for="input9">Data de Entrada</label>
+          <label for="input9">Data de Entrada<span class="required">*</span></label>
           <input id="input9" type="date" th:field="*{data_entrada}" placeholder="2024-03-30" required>
         </div>
       </div>
       <div class="input-container-novo-cadastro">
         <div class="input-group">
-          <label for="input13">Última Manutenção</label>
+          <label for="input13">Última Manutenção<span class="required">*</span></label>
           <input id="input13" type="date" th:field="*{ultima_qualificacao}" placeholder="2024-03-30" required>
         </div>
         <div class="input-group">
-          <label for="input14">Próxima Manutenção</label>
+          <label for="input14">Próxima Manutenção<span class="required">*</span></label>
           <input id="input14" type="date" th:field="*{proxima_qualificacao}" placeholder="2024-03-30" required>
         </div>
         <div class="input-group">
-          <label for="input15">Prazo de Manutenção</label>
+          <label for="input15">Prazo de Manutenção<span class="required">*</span></label>
           <input id="input15" type="date" th:field="*{prazo_manutencao}" placeholder="2024-03-30" required>
         </div>
       </div>
       <div class="input-container-novo-cadastro">
         <div class="input-group">
           <label for="input16">Comentários Sobre a Última Manutenção</label>
-          <input id="input16" type="text" th:field="*{comentario_manutencao}" placeholder="Comentário" required>
+          <input id="input16" type="text" th:field="*{comentario_manutencao}" placeholder="Comentário">
         </div>
         <div class="input-group">
-          <label for="input17">Status</label>
+          <label for="input17">Status<span class="required">*</span></label>
           <select id="input17" th:field="*{status}" required>
             <option value="">Selecione o status</option>
             <option th:each="status : ${statuses}" th:value="${status.id_status}" th:text="${status.nome}"></option>

--- a/controledeestoque/src/main/resources/templates/NovoCadastro.html
+++ b/controledeestoque/src/main/resources/templates/NovoCadastro.html
@@ -176,8 +176,12 @@
           <input id="input16" type="text" th:field="*{comentario_manutencao}" placeholder="Comentário">
         </div>
         <div class="input-group">
-          <label for="input17">Status<span class="required">*</span></label>
-          <select id="input17" th:field="*{status}" required>
+          <label for="input17">Patrimônio<span class="required">*</span></label>
+          <input id="input17" type="text" th:field="*{patrimonio}" placeholder="123456" required>
+        </div>
+        <div class="input-group">
+          <label for="input18">Status<span class="required">*</span></label>
+          <select id="input18" th:field="*{status}" required>
             <option value="">Selecione o status</option>
             <option th:each="status : ${statuses}" th:value="${status.id_status}" th:text="${status.nome}"></option>
           </select>

--- a/controledeestoque/src/main/resources/templates/infoEspecifica.html
+++ b/controledeestoque/src/main/resources/templates/infoEspecifica.html
@@ -168,8 +168,12 @@
         <input id="input15" type="text" th:value="${item.comentario_manutencao}" readonly>
       </div>
       <div class="input-group">
-        <label for="input16">Status</label>
-        <input id="input16" type="text" th:value="${item.status.nome}" readonly>
+        <label for="input16">Patrimônio</label>
+        <input id="input16" type="text" th:value="${item.patrimonio}" readonly>
+      </div>
+      <div class="input-group">
+        <label for="input17">Status</label>
+        <input id="input17" type="text" th:value="${item.status.nome}" readonly>
       </div>
       <!--      colocar no banco ?  -->
       <div class="input-group" style="display: none;">


### PR DESCRIPTION
Na página de cadastro de itens todos os campos foram definidos como obrigatórios exceto "Potência" e "Comentários Sobre a Última Manutenção". Na página de empréstimo de um item, todos os campos editáveis são obrigatórios, exceto "Comentários Sobre a Manutenção" e "Anexos". Todos os campos obrigatórios agora tem uma indicação visual ao lado da label, sendo um "*" com a cor da fonte vermelha. Na página de empréstimo, algumas tags <select> editáveis precisam de um ajuste no backend para terem um placeholder "Selecione o/a (algum dado)", então eu removi esses placeholders, já que com eles, o empréstimo pode ser feito sem a inserção de nenhum dado.