### PR TITLE
fix: emprestantes page e status devolução

### DIFF
--- a/controledeestoque/src/main/java/com/inventario/imobilizado/controller/HtmlController.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/controller/HtmlController.java
@@ -258,7 +258,7 @@ public class HtmlController {
         }
 
         itemInterface.findById(id).map(item -> {
-            item.setEstado("Disponível");
+            item.setEstado("Disponivel");
             return itemInterface.save(item);
         }).orElseThrow();
 

--- a/controledeestoque/src/main/java/com/inventario/imobilizado/controller/ItemController.java
+++ b/controledeestoque/src/main/java/com/inventario/imobilizado/controller/ItemController.java
@@ -126,7 +126,7 @@ public ResponseEntity<?> Devolucao(@RequestBody List<Integer> id_itens) {
         Optional<Item> optionalItem = itemInterface.findById(id);
         if (optionalItem.isPresent()) {
             Item item = optionalItem.get();
-            item.setEstado("Disponível");
+            item.setEstado("Disponivel");
             itemInterface.save(item);
             messages.add("Item com ID " + id + " atualizado para 'Disponível'.");
         } else {

--- a/controledeestoque/src/main/resources/templates/infoEspecifica.html
+++ b/controledeestoque/src/main/resources/templates/infoEspecifica.html
@@ -109,7 +109,7 @@
       </div>
       <div class="input-group">
         <label for="input-disponibilidade">Disponibilidade</label>
-        <input id="input-disponibilidade" type="text" th:value="${item.estado}" th:classappend="${item.estado.equals('Disponível') ? 'green' : item.estado.equals('Emprestado') ? 'blue' : 'yellow'}" readonly>
+        <input id="input-disponibilidade" type="text" th:value="${item.estado}" th:classappend="${item.estado.equals('Disponivel') ? 'green' : item.estado.equals('Emprestado') ? 'blue' : 'yellow'}" readonly>
       </div>
     </div>
     <div class="input-container">
@@ -198,8 +198,8 @@
       <div id="content1" th:class="'tab-content ' + (${action.item.estado.equals('Emprestado') ? 'status-yellow' :
     (action.item.estado.equals('Manutencao') ? 'status-blue' : 'status-green')})">
       <p>
-        <span th:text="${action.usuario.nome}"></span> <span th:text="${action.item.estado.equals('Disponível') ? 'devolveu' : action.item.estado.equals('Emprestado') ? 'emprestou' : 'mandou para manutenção'}"></span>
-          para  <span th:text="${action.item.estado.equals('Disponível') ? action.item.localizacao.nome : 'empresa ' + action.entidade}"></span> no dia <span th:text="${action.data_emprestimo}"></span>.
+        <span th:text="${action.usuario.nome}"></span> <span th:text="${action.item.estado.equals('Disponivel') ? 'devolveu' : action.item.estado.equals('Emprestado') ? 'emprestou' : 'mandou para manutenção'}"></span>
+          para  <span th:text="${action.item.estado.equals('Disponivel') ? action.item.localizacao.nome : 'empresa ' + action.entidade}"></span> no dia <span th:text="${action.data_emprestimo}"></span>.
       </div>
       </p>
       <button class="content-button" id="button1" style="display: none;"></button>

--- a/projeto_integrador/lib/pages/emprestantes_page.dart
+++ b/projeto_integrador/lib/pages/emprestantes_page.dart
@@ -12,9 +12,8 @@ class EmprestantesPage extends StatefulWidget {
   State<EmprestantesPage> createState() => _EmprestantesPageState();
 }
 
-final TextEditingController _searchController = TextEditingController();
-
 class _EmprestantesPageState extends State<EmprestantesPage> {
+  final TextEditingController _searchController = TextEditingController();
   List<Emprestante> emprestantes = [];
   bool _isSelecting = false;
   List<bool> _selectedEmprestantes = [];
@@ -24,6 +23,15 @@ class _EmprestantesPageState extends State<EmprestantesPage> {
   void initState() {
     super.initState();
     _loadEmprestantes();
+    _searchController.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
   }
 
   Future<void> _navigateToEmprestanteRegistrationPage() async {
@@ -57,15 +65,11 @@ class _EmprestantesPageState extends State<EmprestantesPage> {
   }
 
   List<Emprestante> get filteredEmprestantes {
-    if (_searchController.text.isEmpty) {
-      return emprestantes;
-    } else {
-      return emprestantes
-          .where((emprestante) => emprestante.nome
-              .toLowerCase()
-              .contains(_searchController.text.toLowerCase()))
-          .toList();
-    }
+    return emprestantes.where((emprestante) {
+      return emprestante.nome
+          .toLowerCase()
+          .contains(_searchController.text.toLowerCase());
+    }).toList();
   }
 
   void _toggleSelection(int index) {
@@ -147,20 +151,6 @@ class _EmprestantesPageState extends State<EmprestantesPage> {
 
   void _navigateToEmprestanteEditPage(
       BuildContext context, Emprestante selectedEmprestante) async {
-    final selectedCount =
-        _selectedEmprestantes.where((selected) => selected).length;
-
-    if (selectedCount != 1) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content:
-              Text('Por favor, selecione apenas um emprestante para editar.'),
-          backgroundColor: Colors.red,
-        ),
-      );
-      return;
-    }
-
     try {
       final bool? result = await Navigator.of(context).push(
         PageRouteBuilder(

--- a/projeto_integrador/lib/pages/inventario_page.dart
+++ b/projeto_integrador/lib/pages/inventario_page.dart
@@ -38,39 +38,41 @@ class _InventarioPageState extends State<InventarioPage> {
   }
 
   void _devolucaoItem() async {
-  try {
-    final List<int> itemIds = _items
-        .asMap()
-        .entries
-        .where((entry) => _selectedItems[entry.key])
-        .map((entry) => entry.value.id)
-        .toList();
+    try {
+      final List<int> itemIds = _items
+          .asMap()
+          .entries
+          .where((entry) => _selectedItems[entry.key])
+          .map((entry) => entry.value.id)
+          .toList();
 
-    if (itemIds.isNotEmpty) {
-      await ItemService.returnItems(itemIds);
+      if (itemIds.isNotEmpty) {
+        await ItemService.returnItems(itemIds);
 
-      // Atualiza o estado local dos itens apenas para os que foram devolvidos
-      this.loading();
+        // Atualiza o estado local dos itens apenas para os que foram devolvidos
+        this.loading();
 
-      this._isSelecting = false;
+        this._isSelecting = false;
 
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Itens devolvidos com sucesso'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+              content: Text('Nenhum item selecionado para devolução')),
+        );
+      }
+    } catch (e) {
+      print("Erro ao devolver itens: $e");
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Itens devolvidos com sucesso'),
-        backgroundColor: Colors.green,
-        ),
-      );
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Nenhum item selecionado para devolução')),
+        const SnackBar(content: Text('Erro ao devolver itens')),
       );
     }
-  } catch (e) {
-    print("Erro ao devolver itens: $e");
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Erro ao devolver itens')),
-    );
   }
-}
 
   void _navigateToEmprestimoPage(BuildContext context) async {
     try {
@@ -117,7 +119,8 @@ class _InventarioPageState extends State<InventarioPage> {
     final bool? result = await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => ItemEditPage(id: id), // Passando o item selecionado
+        builder: (context) =>
+            ItemEditPage(id: id), // Passando o item selecionado
       ),
     );
 
@@ -248,7 +251,6 @@ class _InventarioPageState extends State<InventarioPage> {
                 ),
               ),
               const SizedBox(height: 10),
-
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 50),
                 child: DropdownButton<String>(
@@ -292,7 +294,8 @@ class _InventarioPageState extends State<InventarioPage> {
                               if (_isSelecting) {
                                 _toggleSelection(index);
                               } else {
-                                _navigateToEditItem(_items[index].id); // Navegando para a tela de edição
+                                _navigateToEditItem(_items[index]
+                                    .id); // Navegando para a tela de edição
                               }
                             },
                             child: ListTile(
@@ -313,7 +316,8 @@ class _InventarioPageState extends State<InventarioPage> {
                                               ? "Manutenção"
                                               : "Indefinido",
                                   style: TextStyle(
-                                    color: item.estado == "Disponivel"     //acho valido usar um text e não mudar no banco
+                                    color: item.estado ==
+                                            "Disponivel" //acho valido usar um text e não mudar no banco
                                         ? Theme.of(context)
                                             .colorScheme
                                             .inversePrimary
@@ -371,7 +375,8 @@ class _InventarioPageState extends State<InventarioPage> {
                 const SizedBox(height: 20),
                 FloatingActionButton(
                   backgroundColor: const Color.fromARGB(255, 30, 95, 179),
-                  onPressed: () { _devolucaoItem(); 
+                  onPressed: () {
+                    _devolucaoItem();
                   },
                   child: const Icon(Icons.subdirectory_arrow_left),
                 ),


### PR DESCRIPTION
Quando um item é devolvido, agora o status é redefinido para 'Disponivel' ao invés de 'Disponível'. Também na página de emprestantes, agora a barra de pesquisa funciona como nas demais páginas e a página de edição abre normalmente com um clique no emprestante